### PR TITLE
Metatietoputki20230302

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-marc-record-merge-reducers",
-	"version": "1.2.1-alpha.1",
+	"version": "1.2.2-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-marc-record-merge-reducers",
-			"version": "1.2.1-alpha.1",
+			"version": "1.2.2-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-marc-record-merge-reducers-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "1.2.1-alpha.1",
+	"version": "1.2.2-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=14"

--- a/src/reducers/mergableIndicator.js
+++ b/src/reducers/mergableIndicator.js
@@ -2,7 +2,7 @@
 //import createDebugLogger from 'debug';
 //import {/*fieldToString,*/ nvdebug} from './utils';
 
-import {fieldToString, marc21GetTagsLegalInd1Value, marc21GetTagsLegalInd2Value, nvdebug} from './utils';
+import {marc21GetTagsLegalInd1Value, marc21GetTagsLegalInd2Value, nvdebug} from './utils';
 
 //import {sortAdjacentSubfields} from './sortSubfields';
 // import identicalFields from '@natlibfi/marc-record-validators-melinda/dist/identical-fields';
@@ -56,11 +56,12 @@ export function mergableIndicator1(field1, field2, config) {
 }
 
 export function mergableIndicator2(field1, field2, config) {
-  nvdebug(`mergableIndicator2\n '${fieldToString(field1)}' vs\n '${fieldToString(field2)}'`);
   // Indicators are identical:
   if (field1.ind2 === field2.ind2) {
     return true;
   }
+
+  // nvdebug(`mergableIndicator2\n '${fieldToString(field1)}' vs\n '${fieldToString(field2)}'`);
 
   // NB! Our 260 vs 264 hacks...NB #2: We do this split check only for ind2, not for ind1.
   // Maybe reasons to this for ind1 will rise later on. None known yetr though.

--- a/src/reducers/mergeConstraints.js
+++ b/src/reducers/mergeConstraints.js
@@ -30,7 +30,7 @@ const mergeConstraints = [
   {'tag': '037', 'required': 'b', 'key': 'ab'},
   {'tag': '039', 'required': 'a'},
   {'tag': '040', 'required': '', 'key': ''},
-  {'tag': '041', 'required': '', 'key': ''},
+  {'tag': '041', 'required': '', 'paired': '2', 'key': ''}, // Don't put $2 in 'key'! hasCommonNominator() would get into trouble with it...
   {'tag': '042', 'required': 'a', 'key': ''}, // NB: preprocessor hacks applied
   {'tag': '043', 'required': 'a', 'key': 'abc'},
   {'tag': '044', 'required': '', 'key': 'abc', 'paired': 'abc'},
@@ -53,7 +53,7 @@ const mergeConstraints = [
   {'tag': '080', 'required': 'a', 'paired': 'bx', 'key': 'abx'},
   {'tag': '082', 'required': 'a', 'paired': 'b', 'key': 'abmq2'},
   {'tag': '083', 'required': 'a', 'paired': 'b', 'key': 'abmqy'},
-  {'tag': '084', 'required': 'a', 'paired': 'b', 'key': 'abq'},
+  {'tag': '084', 'required': 'a', 'paired': 'b2', 'key': 'abq2'},
   {'tag': '085', 'required': '', 'paired': 'abcfrstuvwyz', 'key': 'abcfrstuvwxyz'},
   {'tag': '086', 'required': '', 'paired': 'a', 'key': 'a'},
   {'tag': '088', 'required': '', 'paired': 'a', 'key': 'a'},
@@ -146,7 +146,7 @@ const mergeConstraints = [
   {'tag': '530', 'required': 'a', 'paired': 'abcd', 'key': 'abcd'},
   {'tag': '532', 'required': 'a', 'key': 'a'},
   {'tag': '533', 'required': 'a', 'paired': 'abcdefmn7', 'key': 'abcdefmn7'},
-  {'tag': '534', 'required': 'a', 'paired': 'abcempt', 'key': 'abcempt'},
+  {'tag': '534', 'required': '', 'paired': 'abcempt', 'key': 'abcempt'},
   {'tag': '535', 'required': '', 'paired': 'abcdg', 'key': 'abcdg'},
   {'tag': '536', 'required': '', 'paired': 'abcdefgh', 'key': 'abcdefgh'},
   {'tag': '538', 'required': 'a', 'paired': 'aiu', 'key': 'aiu'},

--- a/src/reducers/mergeIndicator.js
+++ b/src/reducers/mergeIndicator.js
@@ -161,11 +161,13 @@ export function mergeIndicators(toField, fromField, config) {
   }
 
   function mergeIndicator2(toField, fromField, config) {
-    nvdebug(`Merge IND2`);
-    nvdebug(` ${fieldToString(toField)}\n ${fieldToString(fromField)}`);
     if (toField.ind2 === fromField.ind2) {
       return; // Do nothing
     }
+
+    //nvdebug(`Merge IND2`);
+    //nvdebug(` ${fieldToString(toField)}\n ${fieldToString(fromField)}`);
+
 
     publisherTagSwapHack(toField, fromField); // Easter egg/hack for base-260 vs source-264
 

--- a/src/reducers/normalize.js
+++ b/src/reducers/normalize.js
@@ -25,6 +25,7 @@ function debugFieldComparison(oldField, newField) { // NB: Debug-only function!
       }
     });
   }
+
   nvdebug(`NORMALIZE FIELD:\n '${fieldToString(oldField)}' =>\n '${fieldToString(newField)}'`);
 }
 
@@ -93,8 +94,8 @@ function subfieldValueLowercase(value, subfieldCode, tag) {
   //return value.toLowerCase();
   const newValue = value.toLowerCase();
   if (newValue !== value) {
-    nvdebug(`SVL ${tag} $${subfieldCode} '${value}' =>`);
-    nvdebug(`SVL ${tag} $${subfieldCode} '${newValue}'`);
+    //nvdebug(`SVL ${tag} $${subfieldCode} '${value}' =>`);
+    //nvdebug(`SVL ${tag} $${subfieldCode} '${newValue}'`);
     return newValue;
   }
   return value;

--- a/src/reducers/postprocessSubfield6.js
+++ b/src/reducers/postprocessSubfield6.js
@@ -1,6 +1,6 @@
 import createDebugLogger from 'debug';
-import {isRelevantField6, isValidSubfield6, pairAndStringify6, removeField6IfNeeded} from './subfield6Utils';
-import {fieldHasSubfield, fieldToString, nvdebug} from './utils';
+import {isRelevantField6, isValidSubfield6, pairAndStringify6, removeField6IfNeeded, subfieldGetIndex6} from './subfield6Utils';
+import {fieldHasSubfield, fieldToString, nvdebug, subfieldToString} from './utils';
 
 const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers');
 //const debugData = debug.extend('data');
@@ -46,8 +46,8 @@ function subfieldApplies(subfield, lookFor) {
 
 
 function getPairValue(subfield6, myTag) {
-  const index = subfield6.value.replace(/^[0-9][0-9][0-9]-([0-9][0-9]+).*$/u, '$1'); // eslint-disable-line prefer-named-capture-group
-
+  //const index = subfield6.value.replace(/^[0-9][0-9][0-9]-([0-9][0-9]+).*$/u, '$1'); // eslint-disable-line prefer-named-capture-group
+  const index = subfieldGetIndex6(subfield6);
   const lookFor = `${myTag}-${index}`;
   return lookFor;
 }
@@ -82,6 +82,9 @@ function cleanAndReturnTrueIfDeletable(field, fields) {
     if (field.tag !== '880' || pairlessSixes.length < sixes.length) {
       const remainingSubfields = field.subfields.filter(sf => pairlessSixes.every(sf2 => sf2.code !== sf.code || sf2.value !== sf.value));
       if (remainingSubfields.length) { // Just clean up the crappy $6s as decent $6 remains
+        const removables = field.subfields.filter(sf => pairlessSixes.every(sf2 => sf2.code === sf.code && sf2.value === sf.value));
+        removables.forEach(sf => nvdebug(`Remove pairless $6 subfield: ${subfieldToString(sf)}`));
+
         field.subfields = remainingSubfields; // eslint-disable-line functional/immutable-data
         return false;
       }

--- a/src/reducers/punctuation.js
+++ b/src/reducers/punctuation.js
@@ -116,6 +116,7 @@ const cleanValidPunctuationRules = {
     {'code': 'axy', 'followedBy': 'xy', 'remove': /,$/u},
     {'code': 'axy', 'followedBy': 'v', 'remove': / ;$/u}
   ],
+  '534': [{'code': 'p', 'followedBy': 'c', 'remove': /:$/u}],
   '773': [{'code': dotSpaceMinus773, 'followedBy': dotSpaceMinus773, 'remove': field773NeedsPunc}]
 };
 
@@ -152,6 +153,8 @@ const addPairedPunctuationRules = {
     {'code': 'axy', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
     {'code': 'axy', 'followedBy': 'v', 'add': ' ;', 'context': defaultNeedsPuncAfter}
   ],
+  '506': [{'code': 'a', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter2}],
+  '534': [{'code': 'p', 'followedBy': 'c', 'add': ':', 'context': defaultNeedsPuncAfter2}],
   '600': [addX00aComma, addX00aDot],
   '610': addX10,
   '700': [addX00aComma, addX00aDot],

--- a/src/reducers/worldKnowledge.js
+++ b/src/reducers/worldKnowledge.js
@@ -1,3 +1,5 @@
+import {nvdebug} from './utils';
+
 export function valueCarriesMeaning(tag, subfieldCode, value) {
   if (tag === '260' || tag === '264') {
     // We drop these, instead of normalizing, as KV does not put this information in place...
@@ -16,21 +18,59 @@ export function valueCarriesMeaning(tag, subfieldCode, value) {
   return true;
 }
 
-export function normalizePersonalName(tag, subfieldCode, originalValue) {
-  if (!['100', '600', '700', '800'].includes(tag) || subfieldCode !== 'a') {
-    return originalValue;
+export function normalizeForSamenessCheck(tag, subfieldCode, originalValue) {
+  const value = normalizeForSamenessCheck2(tag, subfieldCode, originalValue);
+  nvdebug(`SAMENESS: ${originalValue} => ${value}`);
+  return value;
+}
+
+function normalizeForSamenessCheck2(tag, subfieldCode, originalValue) {
+  if (subfieldCode === 'a' && ['100', '600', '700', '800'].includes(tag)) {
+    return normalizePersonalName(originalValue);
   }
+
+  // NB! originalValue should already be lowercased, stripped on initial '[' chars and postpunctuation.
+  if (tag === '250' && subfieldCode === 'a') {
+    return normalizeEditionStatement(originalValue);
+  }
+
+  // 506 - Restrictions on Access Note (R), $a - Terms governing access (NR)
+  if (tag === '506' && subfieldCode === 'a') {
+    return normalize506a(originalValue);
+  }
+
+  if (tag === '534' && subfieldCode === 'p') {
+    return normalizeOriginalVersionNoteIntroductoryPhrase(originalValue);
+  }
+
+  return originalValue;
+}
+
+function normalizePersonalName(originalValue) {
   // Use "Forename Surname" format:
   return originalValue.replace(/^([^,]+), ([^,]+)$/u, '$2 $1'); // eslint-disable-line prefer-named-capture-group
 }
 
-export function normalizeEditionStatement(tag, subfieldCode, originalValue) {
-  if (tag !== '250' && subfieldCode !== 'a') {
-    return originalValue;
+const sallittu506a = ['sallittu kaikenikäisille', 'sallittu', 's']; // downcased, without punctuation
+function normalize506a(originalValue) {
+  if (sallittu506a.includes(originalValue)) {
+    return sallittu506a[0];
+  }
+  return originalValue;
+}
+
+const introductoryPhrasesMeaning1 = ['alkuperäinen', 'alkuperäisen julkaisutiedot', 'alun perin julkaistu', 'alunperin julkaistu'];
+function normalizeOriginalVersionNoteIntroductoryPhrase(originalValue) {
+  // MELKEHITYS-1935-ish:
+  if (introductoryPhrasesMeaning1.includes(originalValue)) {
+    return introductoryPhrasesMeaning1[0];
   }
 
+  return originalValue;
+}
+
+function normalizeEditionStatement(originalValue) {
   const value = originalValue;
-  // NB! originalValue should already be lowercased, stripped on initial '[' chars and postpunctuation.
 
   // As normalization tries to translate things info Finnish, use this for similarity check only!
   if (value.match(/^[1-9][0-9]*(?:\.|:a|nd|rd|st|th) (?:ed\.?|edition|p\.?|painos|uppl\.?|upplagan)[.\]]*$/ui)) {

--- a/test-fixtures/reducers/index/05/base.json
+++ b/test-fixtures/reducers/index/05/base.json
@@ -54,6 +54,30 @@
         }
       ]
     },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-08" },
+      { "code": "a", "value": "Hindley, Kate," },
+      { "code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Andrejev, A." },
+      { "code": "e", "value": "kääntäjä." }
+    ] },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Andrejev, A.," },
+      { "code": "e", "value": "kääntäjä." }
+    ] },
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-08/(N" },
+      {"code": "a", "value": "Хиндли, Кейт," },
+      {"code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-08/(N" },
+      {"code": "a", "value": "Андреев, А.," },
+      {"code": "e", "value": "kääntäjä." }
+    ] },
+
     { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "FIKKA" } ] }
   ]
 }

--- a/test-fixtures/reducers/index/05/merged.json
+++ b/test-fixtures/reducers/index/05/merged.json
@@ -1,6 +1,8 @@
 {
   "leader": "01331cam a22003498i 4500",
   "fields": [
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "swe" } ] },
     { "tag": "042", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "finb" } ] },
     { "tag": "245", "ind1": "0", "ind2": "0", "subfields": [
       { "code": "a", "value": "Pakoretki mestauslavalta /" },
@@ -27,6 +29,32 @@
         { "code": "5", "value": "WHATEVER" }
       ]
     },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Hindley, Kate," },
+      { "code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Andrejev, A." },
+      { "code": "e", "value": "kääntäjä." }
+    ] },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Andrejev, A.," },
+      { "code": "e", "value": "kääntäjä." }
+    ] },
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-01/(N" },
+      {"code": "a", "value": "Хиндли, Кейт," },
+      {"code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-01/(N" },
+      {"code": "a", "value": "Андреев, А.," },
+      {"code": "e", "value": "kääntäjä." }
+    ] },
+
+
     { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "FIKKA" } ] }
   ]
 }

--- a/test-fixtures/reducers/index/05/metadata.json
+++ b/test-fixtures/reducers/index/05/metadata.json
@@ -2,6 +2,7 @@
   "description":"MET-33: Best 500 prepub and 594 Fennica prepub note are retained. MET-197 title: don't merge",
   "comment": "Note that 594 field drops affect only $5 FENNI/FIKKA/VIOLA and thus the field with $5 WHATEVER is retained",
   "comment 2": "Same as test 04 except LDR/17=8 for both records, thus best 500 prepub field is kept.",
+  "comment 3": "Added MRA-245-ish tests. Added MRA-223 fields...",
   "only": false
 
 }

--- a/test-fixtures/reducers/index/05/source.json
+++ b/test-fixtures/reducers/index/05/source.json
@@ -2,6 +2,8 @@
   "leader": "01331cam a22003498i 4500",
   "fields": [
     { "tag": "LOW", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "FIKKA" } ] },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "swe" } ] },
     { "tag": "042", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "finb" } ] },
     { "tag": "245", "ind1": "0", "ind2": "0", "subfields": [
       { "code": "a", "value": "Pakoretki mestauslavalta :" },
@@ -101,6 +103,26 @@
           "value": "WHATEVER"
         }
       ]
-    }
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-08" },
+      { "code": "a", "value": "Hindley, Kate," },
+      { "code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-09" },
+      { "code": "a", "value": "Andrejev, A.," },
+      { "code": "e", "value": "kääntäjä." }
+    ] },
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-08/(N" },
+      {"code": "a", "value": "Хиндли, Кейт," },
+      {"code": "e", "value": "taiteilija." }
+    ] },
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "700-08/(N" },
+      {"code": "a", "value": "Андреев, А.," },
+      {"code": "e", "value": "kääntäjä." }
+    ] }
   ]
 }

--- a/test-fixtures/reducers/index/07/base.json
+++ b/test-fixtures/reducers/index/07/base.json
@@ -2,31 +2,18 @@
   "leader": "01331cam a22003494i 4500",
   "fields": [
     {
-      "tag": "024",
-      "ind1": " ",
-      "ind2": " ",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "FILNM9500119"
-        },
-        {
-          "code": "q",
-          "value": "hft"
-        },
-        {
-          "code": "q",
-          "value": "SID."
-        },
-        {
-          "code": "q",
-          "value": "Mp3,"
-        },
-        {
-          "code": "q",
-          "value": "(pdf)"
-        }
+      "tag": "024", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "FILNM9500119" },
+        { "code": "q", "value": "hft" },
+        { "code": "q", "value": "SID." },
+        { "code": "q", "value": "Mp3," },
+        { "code": "q", "value": "(pdf)" }
       ]
-    }
+    },
+    { "tag": "506", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "Sallittu kaikenikäisille" } ]},
+    { "tag": "534", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "p", "value": "Alun perin julkaistu:" },
+      { "code": "c", "value": "2018." }
+    ]}
   ]
 }

--- a/test-fixtures/reducers/index/07/merged.json
+++ b/test-fixtures/reducers/index/07/merged.json
@@ -27,6 +27,11 @@
           "value": "PDF"
         }
       ]
-    }
+    },
+    { "tag": "506", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "Sallittu kaikenikäisille" } ]},
+    { "tag": "534", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "p", "value": "Alun perin julkaistu:" },
+      { "code": "c", "value": "2018." }
+    ]}
   ]
 }

--- a/test-fixtures/reducers/index/07/metadata.json
+++ b/test-fixtures/reducers/index/07/metadata.json
@@ -1,3 +1,5 @@
 {
-  "description":"Normalize 024$q (despite both base and source have crappier values)"
+  "description":"Normalize 024$q (despite both base and source have crappier values). MRA-309 and MRA-311: normalize 506$a and 534$p as well.",
+  "comment": "NB! 506$a missing final punc is not added; as the base field is not changed, it stays as it is.",
+  "only": false
 }

--- a/test-fixtures/reducers/index/07/source.json
+++ b/test-fixtures/reducers/index/07/source.json
@@ -28,6 +28,12 @@
           "value": "(pdf)"
         }
       ]
-    }
+    },
+    { "tag": "506", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "Sallittu." } ]},
+    { "tag": "506", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "S" } ]},
+    { "tag": "534", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "p", "value": "Alunperin julkaistu:" },
+      { "code": "c", "value": "2018." }
+    ]}
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/field042/01/base.json
+++ b/test-fixtures/reducers/mergeDataFields/field042/01/base.json
@@ -11,6 +11,8 @@
           "value": "testing"
         }
       ]
-    }
+    },
+    { "tag": "045", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "a-c-" } ] },
+    { "tag": "045", "ind1": "0", "ind2": " ", "subfields": [ { "code": "b", "value": "d1975" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/field042/01/merged.json
+++ b/test-fixtures/reducers/mergeDataFields/field042/01/merged.json
@@ -11,6 +11,8 @@
           "value": "testing"
         }
       ]
-    }
+    },
+    { "tag": "045", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "a-c-" } ] },
+    { "tag": "045", "ind1": "0", "ind2": " ", "subfields": [ { "code": "b", "value": "d1975" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/field042/01/metadata.json
+++ b/test-fixtures/reducers/mergeDataFields/field042/01/metadata.json
@@ -1,3 +1,4 @@
 {
-  "description":"Do nothing, as there's nothing to merge"
+  "description":"Do nothing, as there's nothing to merge",
+  "comment": "Added 045 fields here, to check that 045$a and 045$b won't merge"
 }

--- a/test-fixtures/reducers/mergeDataFields/field042/01/modifiedSource.json
+++ b/test-fixtures/reducers/mergeDataFields/field042/01/modifiedSource.json
@@ -11,6 +11,8 @@
           "value": "lc"
         }
       ]
-    }
+    },
+    { "tag": "045", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "d7n6" } ] },
+    { "tag": "045", "ind1": "0", "ind2": " ", "subfields": [ { "code": "b", "value": "d1984" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/field042/01/source.json
+++ b/test-fixtures/reducers/mergeDataFields/field042/01/source.json
@@ -11,6 +11,8 @@
           "value": "lc"
         }
       ]
-    }
+    },
+    { "tag": "045", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "d7n6" } ] },
+    { "tag": "045", "ind1": "0", "ind2": " ", "subfields": [ { "code": "b", "value": "d1984" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/ind1/03/base.json
+++ b/test-fixtures/reducers/mergeDataFields/ind1/03/base.json
@@ -1,104 +1,14 @@
 {
   "leader": "01331cam a22003494i 4500",
   "fields": [
-    {
-      "tag": "506",
-      "ind1": " ",
-      "ind2": "1",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test1"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": " ",
-      "ind2": "2",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test2"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": " ",
-      "ind2": "3",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test3"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "4",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test4"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "5",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test5"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "6",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test6"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "7",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test7"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "8",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test8"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "9",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test9"
-        }
-      ]
-    }
+    { "tag": "506", "ind1": " ", "ind2": "1", "subfields": [ { "code": "a", "value": "test1" } ] },
+    { "tag": "506", "ind1": " ", "ind2": "2", "subfields": [ { "code": "a", "value": "test2" } ] },
+    { "tag": "506", "ind1": " ", "ind2": "3", "subfields": [ { "code": "a", "value": "test3" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "4", "subfields": [ { "code": "a", "value": "test4" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "5", "subfields": [ { "code": "a", "value": "test5" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "6", "subfields": [ { "code": "a", "value": "test6" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "7", "subfields": [ { "code": "a", "value": "test7" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "8", "subfields": [ { "code": "a", "value": "test8" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "9", "subfields": [ { "code": "a", "value": "test9" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/ind1/03/merged.json
+++ b/test-fixtures/reducers/mergeDataFields/ind1/03/merged.json
@@ -1,104 +1,14 @@
 {
   "leader": "01331cam a22003494i 4500",
   "fields": [
-    {
-      "tag": "506",
-      "ind1": " ",
-      "ind2": "1",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test1"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "2",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test2"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "3",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test3"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "4",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test4"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "5",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test5"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "0",
-      "ind2": "6",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test6"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "7",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test7"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "8",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test8"
-        }
-      ]
-    },
-    {
-      "tag": "506",
-      "ind1": "1",
-      "ind2": "9",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test9"
-        }
-      ]
-    }
+    { "tag": "506", "ind1": " ", "ind2": "1", "subfields": [ { "code": "a", "value": "test1" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "2", "subfields": [ { "code": "a", "value": "test2" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "3", "subfields": [ { "code": "a", "value": "test3" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "4", "subfields": [ { "code": "a", "value": "test4" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "5", "subfields": [ { "code": "a", "value": "test5" } ] },
+    { "tag": "506", "ind1": "0", "ind2": "6", "subfields": [ { "code": "a", "value": "test6" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "7", "subfields": [ { "code": "a", "value": "test7" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "8", "subfields": [ { "code": "a", "value": "test8" } ] },
+    { "tag": "506", "ind1": "1", "ind2": "9", "subfields": [ { "code": "a", "value": "test9" } ] }
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/ind1/03/source.json
+++ b/test-fixtures/reducers/mergeDataFields/ind1/03/source.json
@@ -1,21 +1,11 @@
 {
   "leader": "01331cam a22003494i 4500",
   "fields": [
-    {
-      "tag": "506",
-      "ind1": " ",
-      "ind2": "1",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "test1"
-        }
-      ]
+    { "tag": "506", "ind1": " ", "ind2": "1", "subfields": [ { "code": "a", "value": "test1" } ]
     },
     {
       "tag": "506",
-      "ind1": "0",
-      "ind2": "2",
+      "ind1": "0", "ind2": "2",
       "subfields": [
         {
           "code": "a",
@@ -25,8 +15,7 @@
     },
     {
       "tag": "506",
-      "ind1": "1",
-      "ind2": "3",
+      "ind1": "1", "ind2": "3",
       "subfields": [
         {
           "code": "a",
@@ -36,8 +25,7 @@
     },
     {
       "tag": "506",
-      "ind1": " ",
-      "ind2": "4",
+      "ind1": " ", "ind2": "4",
       "subfields": [
         {
           "code": "a",
@@ -47,8 +35,7 @@
     },
     {
       "tag": "506",
-      "ind1": "0",
-      "ind2": "5",
+      "ind1": "0", "ind2": "5",
       "subfields": [
         {
           "code": "a",


### PR DESCRIPTION
Fix MRA-309 and MRA-311

Add tests for other stuff (incl. MRA-223) as well.

Somewhat smaller update. Mainly work on given field/subfield sameness-check-only normalization. No preference is given, so base value win (eg. 506$a S vs Sallittu vs Sallittu kaikenikäisille), though sometimes the correct value for 506$a is sometimes known (Here "Sallittu kaikenikäisille" is the form that is used in MTS)