### PR TITLE
Revisit both 710 and sf5

### DIFF
--- a/src/reducers/counterpartField.js
+++ b/src/reducers/counterpartField.js
@@ -16,6 +16,8 @@ const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers:me
 //const debugData = debug.extend('data');
 const debugDev = debug.extend('dev');
 
+const irrelevantSubfieldsInNameAndTitlePartComparison = '5689';
+
 const counterpartRegexps = { // NB! tag is from source!
   // Note that in the normal case, all source 1XX fields have been converted to 7XX fields.
   '100': /^[17]00$/u, '110': /^[17]10$/u, '111': /^[17]11$/u, '130': /^[17]30$/u,
@@ -133,8 +135,8 @@ function optionalSubfieldComparison(originalBaseField, originalSourceField, keyS
     // When everything is the string, the strings need to be (practically) identical.
     // (NB! Here order matters. We should probably make it matter everywhere.)
     // (However, keySubfieldsAsString === '' will always succeed. Used by 040 at least.)
-    // TEE: SKIPPAA INDIKAATTORIT!
-    return fieldToString(field1) === fieldToString(field2);
+    // NB! substring(6) skips "TAG II" (I=indicator. Thus we skip indicators)
+    return fieldToString(field1).substring(6) === fieldToString(field2).substring(6);
   }
   const subfieldArray = keySubfieldsAsString.split('');
 
@@ -397,7 +399,9 @@ function pairableName(baseField, sourceField) {
     return true;
   }
 
-  nvdebug(`    name mismatch: '${fieldToString(reducedField1)}' vs '${fieldToString(reducedField2)}'`, debugDev);
+  nvdebug(`    name mismatch:`);
+  nvdebug(`     '${fieldToString(reducedField1)}' vs`);
+  nvdebug(`     '${fieldToString(reducedField2)}'`, debugDev);
   return false;
 }
 
@@ -441,7 +445,8 @@ function namePartThreshold(field) {
 
 function fieldToNamePart(field) {
   const index = namePartThreshold(field);
-  const relevantSubfields = field.subfields.filter((sf, i) => i < index || index === -1);
+  const relevantSubfields = field.subfields.filter((sf, i) => i < index || index === -1).filter(sf => !irrelevantSubfieldsInNameAndTitlePartComparison.includes(sf.code));
+
   const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: relevantSubfields};
 
   /*
@@ -449,13 +454,17 @@ function fieldToNamePart(field) {
     debugDev(`Name subset: ${fieldToString(subsetField)}`);
   }
   */
+
+  // Ummm... Sometimes $0 comes after $t but belongs to name part
+
   return subsetField;
 }
 
 function fieldToTitlePart(field) {
   // Take everything after 1st subfield $t...
   const index = field.subfields.findIndex(currSubfield => currSubfield.code === 't');
-  const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: field.subfields.filter((sf, i) => i >= index)};
+  const relevantSubfields = field.subfields.filter((sf, i) => i >= index).filter(sf => !irrelevantSubfieldsInNameAndTitlePartComparison.includes(sf.code));
+  const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: relevantSubfields};
   debugDev(`Title subset: ${fieldToString(subsetField)}`);
   return subsetField;
 }

--- a/src/reducers/mergableTag.js
+++ b/src/reducers/mergableTag.js
@@ -51,7 +51,7 @@ const defaultNonMergableFields = [
   '853',
   '854',
   '855',
-  // '856', // This is mergable but so risky, that let's just ignore these
+  // '856' is mergable, but a pain in the ass
   '863',
   '864',
   '865',
@@ -64,7 +64,7 @@ const defaultNonMergableFields = [
   '881',
   '882',
   '883',
-  '884',
+  // '884',
   '885',
   '886',
   '887',

--- a/src/reducers/mergeConstraints.js
+++ b/src/reducers/mergeConstraints.js
@@ -270,7 +270,7 @@ const mergeConstraints = [
   {'tag': '881', 'required': ''},
   {'tag': '882', 'required': ''},
   {'tag': '883', 'required': ''},
-  {'tag': '884', 'required': ''},
+  {'tag': '884', 'required': '', 'paired': 'agkq'},
   {'tag': '885', 'required': ''},
   {'tag': '886', 'required': ''},
   {'tag': '887', 'required': ''},

--- a/test-fixtures/reducers/index/field710_MET502/base.json
+++ b/test-fixtures/reducers/index/field710_MET502/base.json
@@ -7,6 +7,10 @@
       { "code": "e", "value": "kustantaja." },
       {  "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo" },
+      { "code": "e", "value": "kustantaja." }
+    ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (foo)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "WSOY" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Ntamo" } ]},

--- a/test-fixtures/reducers/index/field710_MET502/merged.json
+++ b/test-fixtures/reducers/index/field710_MET502/merged.json
@@ -7,6 +7,11 @@
       { "code": "e", "value": "kustantaja." },
       { "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
+      { "code": "e", "value": "kustantaja." },
+      {  "code": "0", "value": "(FI-ASTERI-N)000555889" }
+    ]},
 
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (foo)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Werner Söderström osakeyhtiö." } ]},

--- a/test-fixtures/reducers/index/field710_MET502/source.json
+++ b/test-fixtures/reducers/index/field710_MET502/source.json
@@ -6,6 +6,11 @@
       { "code": "a", "value": "Karisto" },
       { "code": "e", "value": "kustantaja." }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
+      { "code": "e", "value": "kustantaja." },
+      {  "code": "0", "value": "(FI-ASTERI-N)000555889" }
+    ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (bar)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Werner Söderström osakeyhtiö" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "ntamo" } ]},

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/base.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/base.json
@@ -9,7 +9,7 @@
       { "code": "9", "value": "FENNI<KEEP>" }
     ]},
     { "tag": "600", "ind1": "0", "ind2": "4", "subfields": [
-      { "code": "a", "value": "Harry," },
+      { "code": "a", "value": "harry," },
       { "code": "c", "value": "prinssi, Sussexin herttua." }
     ]},
     { "tag": "610", "ind1": "2", "ind2": "4", "subfields": [
@@ -20,7 +20,7 @@
       { "code": "a", "value": "Työväen paheistusliitto." }
     ]},
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-        { "code": "a", "value": "Manik, Dhyan," },
+        { "code": "a", "value": "Islantilainen, Joku" },
         { "code": "e", "value": "kirjoittaja." }
     ]}
   ]

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/merged.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/merged.json
@@ -24,12 +24,10 @@
       { "code": "a", "value": "Työväen paheistusliitto." },
       { "code": "0", "value": "(FI-ASTERI-N)323880000" }
     ]},
-    {
-      "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-        { "code": "a", "value": "Manik, Dhyan," },
-        { "code": "e", "value": "kirjoittaja." },
-        { "code": "0", "value": "(FI-ASTERI-N)000077333" }
-      ]
-    }
+    { "tag": "700", "ind1": "0", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Joku Islantilainen," },
+      { "code": "e", "value": "kirjoittaja."},
+      { "code": "0", "value": "(FI-ASTERI-N)000077333" }
+    ]}
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/metadata.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/metadata.json
@@ -1,5 +1,6 @@
 {
   "description":"00 merge X00, keep 710. Now also test MRA-331, MRA-414.",
   "MRA-414": "600 and 610 fields should merge",
+  "NB #1": "MELINDA-506 prefers Harry and \"Joku Islantilainen\" field from source, since it has an Asteri $0 ",
   "only": false
 }

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/source.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/source.json
@@ -6,7 +6,7 @@
       { "code": "c", "value": "Sussexin herttuatar." }
     ]},
     { "tag": "600", "ind1": "0", "ind2": "4", "subfields": [
-      { "code": "a", "value": "harry" },
+      { "code": "a", "value": "Harry," },
       { "code": "c", "value": "prinssi, Sussexin herttua." },
       { "code": "0", "value": "(FI-ASTERI-N)000189324" },
       { "code": "9", "value": "FENNI<KEEP>" }
@@ -20,7 +20,7 @@
     ]},
     { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "Tuisku, Sara." } ] },
     { "tag": "700", "ind1": "0", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Dhyan Manik." },
+      { "code": "a", "value": "Joku Islantilainen." },
       { "code": "0", "value": "(FI-ASTERI-N)000077333" }
     ]},
     { "tag": "710", "ind1": "1", "ind2": " ", "subfields": [ { "code": "a", "value": "Helsingin yliopisto." } ] }


### PR DESCRIPTION
Fix MET-502: make field 884 mergeable, set merge constraints for it. Also fix a bug in field counterpart decisions. (Controlfields $5 and $9 were used in name&title part comparisons, if no subfield code was required. Removed these controlfields from comparisons). 

Improve MELINDA-8978: if source has an Asteri $0, and the counterpart base field has not, use the source field as the field, to which the other fields' subfields are merged. 