### PR TITLE
Merge updates (#114) & Dependency Update (#113)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-marc-record-merge-reducers",
-	"version": "2.0.21-alpha.1",
+	"version": "2.0.21-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-marc-record-merge-reducers",
-			"version": "2.0.21-alpha.1",
+			"version": "2.0.21-alpha.2",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-marc-record-merge-reducers",
-	"version": "2.0.21-alpha.2",
+	"version": "2.0.21-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-marc-record-merge-reducers",
-			"version": "2.0.21-alpha.2",
+			"version": "2.0.21-alpha.3",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,28 +103,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-			"integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+			"integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+			"integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
+				"@babel/generator": "^7.23.3",
 				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helper-module-transforms": "^7.23.3",
 				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.0",
+				"@babel/parser": "^7.23.3",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0",
+				"@babel/traverse": "^7.23.3",
+				"@babel/types": "^7.23.3",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -158,11 +158,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+			"integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
 			"dependencies": {
-				"@babel/types": "^7.23.0",
+				"@babel/types": "^7.23.3",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -321,9 +321,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-module-imports": "^7.22.15",
@@ -515,9 +515,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+			"integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -526,9 +526,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.22.15.tgz",
-			"integrity": "sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
+			"integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -541,20 +541,36 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.22.15.tgz",
-			"integrity": "sha512-Hyph9LseGvAeeXzikV88bczhsrLrIZqDPxO+sSmAunMPaGrBGhfMWzCPYTtiW9t+HzSE2wtV8e5cc5P6r1xMDQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
+			"integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.22.15"
+				"@babel/plugin-transform-optional-chaining": "^7.23.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.13.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.3.tgz",
+			"integrity": "sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-plugin-utils": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -633,9 +649,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.22.5.tgz",
-			"integrity": "sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
+			"integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -648,9 +664,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.22.5.tgz",
-			"integrity": "sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
+			"integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -805,9 +821,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.22.5.tgz",
-			"integrity": "sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
+			"integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -820,9 +836,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.2.tgz",
-			"integrity": "sha512-BBYVGxbDVHfoeXbOwcagAkOQAm9NxoTdMGfTqghu1GrvadSaw6iW3Je6IcL5PNOw8VwjxqBECXy50/iCQSY/lQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.3.tgz",
+			"integrity": "sha512-59GsVNavGxAXCDDbakWSMJhajASb4kBCqDjqJsv+p5nKdbz7istmZ3HrX3L2LuiI80+zsOADCvooqQH3qGCucQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -838,14 +854,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.22.5.tgz",
-			"integrity": "sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
+			"integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-remap-async-to-generator": "^7.22.5"
+				"@babel/helper-remap-async-to-generator": "^7.22.20"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -855,9 +871,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.22.5.tgz",
-			"integrity": "sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
+			"integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -870,9 +886,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.0.tgz",
-			"integrity": "sha512-cOsrbmIOXmf+5YbL99/S49Y3j46k/T16b9ml8bm9lP6N9US5iQ2yBK7gpui1pg0V/WMcXdkfKbTb7HXq9u+v4g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.3.tgz",
+			"integrity": "sha512-QPZxHrThbQia7UdvfpaRRlq/J9ciz1J4go0k+lPBXbgaNeY7IQrBj/9ceWjvMMI07/ZBzHl/F0R/2K0qH7jCVw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -885,12 +901,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.22.5.tgz",
-			"integrity": "sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
+			"integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.5",
+				"@babel/helper-create-class-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -901,12 +917,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.22.11.tgz",
-			"integrity": "sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.3.tgz",
+			"integrity": "sha512-PENDVxdr7ZxKPyi5Ffc0LjXdnJyrJxyqF5T5YjlVg4a0VFfQHW0r8iAtRiDXkfHlu1wwcvdtnndGYIeJLSuRMQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.11",
+				"@babel/helper-create-class-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5"
 			},
@@ -918,18 +934,18 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.15.tgz",
-			"integrity": "sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.3.tgz",
+			"integrity": "sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
 				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-optimise-call-expression": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.9",
+				"@babel/helper-replace-supers": "^7.22.20",
 				"@babel/helper-split-export-declaration": "^7.22.6",
 				"globals": "^11.1.0"
 			},
@@ -941,13 +957,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.22.5.tgz",
-			"integrity": "sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
+			"integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/template": "^7.22.5"
+				"@babel/template": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -957,9 +973,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.0.tgz",
-			"integrity": "sha512-vaMdgNXFkYrB+8lbgniSYWHsgqK5gjaMNcc84bMIOMRLH0L9AqYq3hwMdvnyqj1OPqea8UtjPEuS/DCenah1wg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
+			"integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -972,12 +988,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.22.5.tgz",
-			"integrity": "sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
+			"integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
+				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -988,9 +1004,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.22.5.tgz",
-			"integrity": "sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
+			"integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1003,9 +1019,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.22.11.tgz",
-			"integrity": "sha512-g/21plo58sfteWjaO0ZNVb+uEOkJNjAaHhbejrnBmu011l/eNDScmkbjCC3l4FKb10ViaGU4aOkFznSu2zRHgA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.3.tgz",
+			"integrity": "sha512-vTG+cTGxPFou12Rj7ll+eD5yWeNl5/8xvQvF08y5Gv3v4mZQoyFf8/n9zg4q5vvCWt5jmgymfzMAldO7orBn7A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1019,12 +1035,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.22.5.tgz",
-			"integrity": "sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
+			"integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.5",
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1035,9 +1051,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.22.11.tgz",
-			"integrity": "sha512-xa7aad7q7OiT8oNZ1mU7NrISjlSkVdMbNxn9IuLZyL9AJEhs1Apba3I+u5riX1dIkdptP5EKDG5XDPByWxtehw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.3.tgz",
+			"integrity": "sha512-yCLhW34wpJWRdTxxWtFZASJisihrfyMOTOQexhVzA78jlU+dH7Dw+zQgcPepQ5F3C6bAIiblZZ+qBggJdHiBAg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1051,9 +1067,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.15.tgz",
-			"integrity": "sha512-me6VGeHsx30+xh9fbDLLPi0J1HzmeIIyenoOQHuw2D4m2SAU3NrspX5XxJLBpqn5yrLzrlw2Iy3RA//Bx27iOA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.3.tgz",
+			"integrity": "sha512-X8jSm8X1CMwxmK878qsUGJRmbysKNbdpTv/O1/v0LuY/ZkZrng5WYiekYSdg9m09OTmDDUWeEDsTE+17WYbAZw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1066,13 +1082,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.22.5.tgz",
-			"integrity": "sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
+			"integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1083,9 +1099,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.22.11.tgz",
-			"integrity": "sha512-CxT5tCqpA9/jXFlme9xIBCc5RPtdDq3JpkkhgHQqtDdiTnTI0jtZ0QzXhr5DILeYifDPp2wvY2ad+7+hLMW5Pw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.3.tgz",
+			"integrity": "sha512-H9Ej2OiISIZowZHaBwF0tsJOih1PftXJtE8EWqlEIwpc7LMTGq0rPOrywKLQ4nefzx8/HMR0D3JGXoMHYvhi0A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1099,9 +1115,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.22.5.tgz",
-			"integrity": "sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
+			"integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1114,9 +1130,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.22.11.tgz",
-			"integrity": "sha512-qQwRTP4+6xFCDV5k7gZBF3C31K34ut0tbEcTKxlX/0KXxm9GLcO14p570aWxFvVzx6QAfPgq7gaeIHXJC8LswQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.3.tgz",
+			"integrity": "sha512-+pD5ZbxofyOygEp+zZAfujY2ShNCXRpDRIPOiBmTO693hhyOEteZgl876Xs9SAHPQpcV0vz8LvA/T+w8AzyX8A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1130,9 +1146,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.22.5.tgz",
-			"integrity": "sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
+			"integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1145,12 +1161,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.0.tgz",
-			"integrity": "sha512-xWT5gefv2HGSm4QHtgc1sYPbseOyf+FFDo2JbpE25GWl5BqTGO9IMwTYJRoIdjsF85GE+VegHxSCUt5EvoYTAw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
+			"integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helper-module-transforms": "^7.23.3",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1161,12 +1177,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.0.tgz",
-			"integrity": "sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
+			"integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helper-module-transforms": "^7.23.3",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-simple-access": "^7.22.5"
 			},
@@ -1178,13 +1194,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.0.tgz",
-			"integrity": "sha512-qBej6ctXZD2f+DhlOC9yO47yEYgUh5CZNz/aBoH4j/3NOlRfJXJbY7xDQCqQVf9KbrqGzIWER1f23doHGrIHFg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
+			"integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helper-module-transforms": "^7.23.3",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-identifier": "^7.22.20"
 			},
@@ -1196,12 +1212,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.22.5.tgz",
-			"integrity": "sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
+			"integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.22.5",
+				"@babel/helper-module-transforms": "^7.23.3",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1228,9 +1244,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.22.5.tgz",
-			"integrity": "sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
+			"integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1243,9 +1259,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.22.11.tgz",
-			"integrity": "sha512-YZWOw4HxXrotb5xsjMJUDlLgcDXSfO9eCmdl1bgW4+/lAGdkjaEvOnQ4p5WKKdUgSzO39dgPl0pTnfxm0OAXcg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.3.tgz",
+			"integrity": "sha512-xzg24Lnld4DYIdysyf07zJ1P+iIfJpxtVFOzX4g+bsJ3Ng5Le7rXx9KwqKzuyaUeRnt+I1EICwQITqc0E2PmpA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1259,9 +1275,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.22.11.tgz",
-			"integrity": "sha512-3dzU4QGPsILdJbASKhF/V2TVP+gJya1PsueQCxIPCEcerqF21oEcrob4mzjsp2Py/1nLfF5m+xYNMDpmA8vffg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.3.tgz",
+			"integrity": "sha512-s9GO7fIBi/BLsZ0v3Rftr6Oe4t0ctJ8h4CCXfPoEJwmvAPMyNrfkOOJzm6b9PX9YXcCJWWQd/sBF/N26eBiMVw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1275,16 +1291,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.15.tgz",
-			"integrity": "sha512-fEB+I1+gAmfAyxZcX1+ZUwLeAuuf8VIg67CTznZE0MqVFumWkh8xWtn58I4dxdVf080wn7gzWoF8vndOViJe9Q==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.3.tgz",
+			"integrity": "sha512-VxHt0ANkDmu8TANdE9Kc0rndo/ccsmfe2Cx2y5sI4hu3AukHQ5wAu4cM7j3ba8B9548ijVyclBU+nuDQftZsog==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
+				"@babel/compat-data": "^7.23.3",
 				"@babel/helper-compilation-targets": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.22.15"
+				"@babel/plugin-transform-parameters": "^7.23.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1294,13 +1310,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.22.5.tgz",
-			"integrity": "sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
+			"integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.5"
+				"@babel/helper-replace-supers": "^7.22.20"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1310,9 +1326,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.11.tgz",
-			"integrity": "sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.3.tgz",
+			"integrity": "sha512-LxYSb0iLjUamfm7f1D7GpiS4j0UAC8AOiehnsGAP8BEsIX8EOi3qV6bbctw8M7ZvLtcoZfZX5Z7rN9PlWk0m5A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1326,9 +1342,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.0.tgz",
-			"integrity": "sha512-sBBGXbLJjxTzLBF5rFWaikMnOGOk/BmK6vVByIdEggZ7Vn6CvWXZyRkkLFK6WE0IF8jSliyOkUN6SScFgzCM0g==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.3.tgz",
+			"integrity": "sha512-zvL8vIfIUgMccIAK1lxjvNv572JHFJIKb4MWBz5OGdBQA0fB0Xluix5rmOby48exiJc987neOmP/m9Fnpkz3Tg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1343,9 +1359,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.15.tgz",
-			"integrity": "sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
+			"integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1358,12 +1374,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.22.5.tgz",
-			"integrity": "sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
+			"integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.5",
+				"@babel/helper-create-class-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1374,13 +1390,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.22.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.22.11.tgz",
-			"integrity": "sha512-sSCbqZDBKHetvjSwpyWzhuHkmW5RummxJBVbYLkGkaiTOWGxml7SXt0iWa03bzxFIx7wOj3g/ILRd0RcJKBeSQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.3.tgz",
+			"integrity": "sha512-a5m2oLNFyje2e/rGKjVfAELTVI5mbA0FeZpBnkOWWV7eSmKQ+T/XW0Vf+29ScLzSxX+rnsarvU0oie/4m6hkxA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.22.11",
+				"@babel/helper-create-class-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
 			},
@@ -1392,9 +1408,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.22.5.tgz",
-			"integrity": "sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
+			"integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1407,9 +1423,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.10.tgz",
-			"integrity": "sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
+			"integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1423,9 +1439,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.22.5.tgz",
-			"integrity": "sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
+			"integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1438,9 +1454,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.22.5.tgz",
-			"integrity": "sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
+			"integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1453,9 +1469,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.22.5.tgz",
-			"integrity": "sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
+			"integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1469,9 +1485,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.22.5.tgz",
-			"integrity": "sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
+			"integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1484,9 +1500,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.22.5.tgz",
-			"integrity": "sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
+			"integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1499,9 +1515,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.22.5.tgz",
-			"integrity": "sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
+			"integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1514,9 +1530,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.22.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.10.tgz",
-			"integrity": "sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
+			"integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1529,12 +1545,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.22.5.tgz",
-			"integrity": "sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
+			"integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
+				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1545,12 +1561,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.22.5.tgz",
-			"integrity": "sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
+			"integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
+				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1561,12 +1577,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.22.5.tgz",
-			"integrity": "sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
+			"integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
+				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5"
 			},
 			"engines": {
@@ -1577,25 +1593,26 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.2.tgz",
-			"integrity": "sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.3.tgz",
+			"integrity": "sha512-ovzGc2uuyNfNAs/jyjIGxS8arOHS5FENZaNn4rtE7UdKMMkqHCvboHfcuhWLZNX5cB44QfcGNWjaevxMzzMf+Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.23.2",
+				"@babel/compat-data": "^7.23.3",
 				"@babel/helper-compilation-targets": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-option": "^7.22.15",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.15",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.22.15",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
 				"@babel/plugin-syntax-class-static-block": "^7.14.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.22.5",
-				"@babel/plugin-syntax-import-attributes": "^7.22.5",
+				"@babel/plugin-syntax-import-assertions": "^7.23.3",
+				"@babel/plugin-syntax-import-attributes": "^7.23.3",
 				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
@@ -1607,56 +1624,55 @@
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.22.5",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.2",
-				"@babel/plugin-transform-async-to-generator": "^7.22.5",
-				"@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-				"@babel/plugin-transform-block-scoping": "^7.23.0",
-				"@babel/plugin-transform-class-properties": "^7.22.5",
-				"@babel/plugin-transform-class-static-block": "^7.22.11",
-				"@babel/plugin-transform-classes": "^7.22.15",
-				"@babel/plugin-transform-computed-properties": "^7.22.5",
-				"@babel/plugin-transform-destructuring": "^7.23.0",
-				"@babel/plugin-transform-dotall-regex": "^7.22.5",
-				"@babel/plugin-transform-duplicate-keys": "^7.22.5",
-				"@babel/plugin-transform-dynamic-import": "^7.22.11",
-				"@babel/plugin-transform-exponentiation-operator": "^7.22.5",
-				"@babel/plugin-transform-export-namespace-from": "^7.22.11",
-				"@babel/plugin-transform-for-of": "^7.22.15",
-				"@babel/plugin-transform-function-name": "^7.22.5",
-				"@babel/plugin-transform-json-strings": "^7.22.11",
-				"@babel/plugin-transform-literals": "^7.22.5",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.22.11",
-				"@babel/plugin-transform-member-expression-literals": "^7.22.5",
-				"@babel/plugin-transform-modules-amd": "^7.23.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.23.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.23.0",
-				"@babel/plugin-transform-modules-umd": "^7.22.5",
+				"@babel/plugin-transform-arrow-functions": "^7.23.3",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.3",
+				"@babel/plugin-transform-async-to-generator": "^7.23.3",
+				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
+				"@babel/plugin-transform-block-scoping": "^7.23.3",
+				"@babel/plugin-transform-class-properties": "^7.23.3",
+				"@babel/plugin-transform-class-static-block": "^7.23.3",
+				"@babel/plugin-transform-classes": "^7.23.3",
+				"@babel/plugin-transform-computed-properties": "^7.23.3",
+				"@babel/plugin-transform-destructuring": "^7.23.3",
+				"@babel/plugin-transform-dotall-regex": "^7.23.3",
+				"@babel/plugin-transform-duplicate-keys": "^7.23.3",
+				"@babel/plugin-transform-dynamic-import": "^7.23.3",
+				"@babel/plugin-transform-exponentiation-operator": "^7.23.3",
+				"@babel/plugin-transform-export-namespace-from": "^7.23.3",
+				"@babel/plugin-transform-for-of": "^7.23.3",
+				"@babel/plugin-transform-function-name": "^7.23.3",
+				"@babel/plugin-transform-json-strings": "^7.23.3",
+				"@babel/plugin-transform-literals": "^7.23.3",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.23.3",
+				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
+				"@babel/plugin-transform-modules-amd": "^7.23.3",
+				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.23.3",
+				"@babel/plugin-transform-modules-umd": "^7.23.3",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
-				"@babel/plugin-transform-new-target": "^7.22.5",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.22.11",
-				"@babel/plugin-transform-numeric-separator": "^7.22.11",
-				"@babel/plugin-transform-object-rest-spread": "^7.22.15",
-				"@babel/plugin-transform-object-super": "^7.22.5",
-				"@babel/plugin-transform-optional-catch-binding": "^7.22.11",
-				"@babel/plugin-transform-optional-chaining": "^7.23.0",
-				"@babel/plugin-transform-parameters": "^7.22.15",
-				"@babel/plugin-transform-private-methods": "^7.22.5",
-				"@babel/plugin-transform-private-property-in-object": "^7.22.11",
-				"@babel/plugin-transform-property-literals": "^7.22.5",
-				"@babel/plugin-transform-regenerator": "^7.22.10",
-				"@babel/plugin-transform-reserved-words": "^7.22.5",
-				"@babel/plugin-transform-shorthand-properties": "^7.22.5",
-				"@babel/plugin-transform-spread": "^7.22.5",
-				"@babel/plugin-transform-sticky-regex": "^7.22.5",
-				"@babel/plugin-transform-template-literals": "^7.22.5",
-				"@babel/plugin-transform-typeof-symbol": "^7.22.5",
-				"@babel/plugin-transform-unicode-escapes": "^7.22.10",
-				"@babel/plugin-transform-unicode-property-regex": "^7.22.5",
-				"@babel/plugin-transform-unicode-regex": "^7.22.5",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
+				"@babel/plugin-transform-new-target": "^7.23.3",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.3",
+				"@babel/plugin-transform-numeric-separator": "^7.23.3",
+				"@babel/plugin-transform-object-rest-spread": "^7.23.3",
+				"@babel/plugin-transform-object-super": "^7.23.3",
+				"@babel/plugin-transform-optional-catch-binding": "^7.23.3",
+				"@babel/plugin-transform-optional-chaining": "^7.23.3",
+				"@babel/plugin-transform-parameters": "^7.23.3",
+				"@babel/plugin-transform-private-methods": "^7.23.3",
+				"@babel/plugin-transform-private-property-in-object": "^7.23.3",
+				"@babel/plugin-transform-property-literals": "^7.23.3",
+				"@babel/plugin-transform-regenerator": "^7.23.3",
+				"@babel/plugin-transform-reserved-words": "^7.23.3",
+				"@babel/plugin-transform-shorthand-properties": "^7.23.3",
+				"@babel/plugin-transform-spread": "^7.23.3",
+				"@babel/plugin-transform-sticky-regex": "^7.23.3",
+				"@babel/plugin-transform-template-literals": "^7.23.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.23.3",
+				"@babel/plugin-transform-unicode-escapes": "^7.23.3",
+				"@babel/plugin-transform-unicode-property-regex": "^7.23.3",
+				"@babel/plugin-transform-unicode-regex": "^7.23.3",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"@babel/types": "^7.23.0",
 				"babel-plugin-polyfill-corejs2": "^0.4.6",
 				"babel-plugin-polyfill-corejs3": "^0.8.5",
 				"babel-plugin-polyfill-regenerator": "^0.5.3",
@@ -1733,18 +1749,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+			"integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
+				"@babel/generator": "^7.23.3",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.0",
-				"@babel/types": "^7.23.0",
+				"@babel/parser": "^7.23.3",
+				"@babel/types": "^7.23.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1753,9 +1769,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+			"integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.22.5",
 				"@babel/helper-validator-identifier": "^7.22.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-marc-record-merge-reducers",
-	"version": "2.0.20",
+	"version": "2.0.21-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-marc-record-merge-reducers",
-			"version": "2.0.20",
+			"version": "2.0.21-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-marc-record-merge-reducers-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "2.0.21-alpha.1",
+	"version": "2.0.21-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-marc-record-merge-reducers-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "2.0.21-alpha.2",
+	"version": "2.0.21-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-marc-record-merge-reducers-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "2.0.20",
+	"version": "2.0.21-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/src/reducers/controlSubfields.js
+++ b/src/reducers/controlSubfields.js
@@ -185,7 +185,7 @@ function controlSubfield9PermitsMerge(baseField, sourceField) {
     if (keepOrDrop2.length === 0) {
       const unhandledSubfield = sf9lessField2.find(sf2 => !sf9lessField1.some(sf => acceptKeeplessSourceSubfield(sf2, baseField.tag, sf.code, sf.value)));
       if (unhandledSubfield) {
-        //nvdebug(`Failed to pair ${subfieldToString(unhandledSubfield)}`);
+        //nvdebug(`Failed to pair ${subfieldToString(unhandledSubfield)}`, debugDev);
         return true;
       }
       //return !sf9lessField2.every(sf2 => sf9lessField1.some(sf => subfieldsAreIdentical(sf, sf2)));

--- a/src/reducers/counterpartField.js
+++ b/src/reducers/counterpartField.js
@@ -399,8 +399,8 @@ function pairableName(baseField, sourceField) {
     return true;
   }
 
-  nvdebug(`    name mismatch:`);
-  nvdebug(`     '${fieldToString(reducedField1)}' vs`);
+  nvdebug(`    name mismatch:`, debugDev);
+  nvdebug(`     '${fieldToString(reducedField1)}' vs`, debugDev);
   nvdebug(`     '${fieldToString(reducedField2)}'`, debugDev);
   return false;
 }

--- a/src/reducers/counterpartField.js
+++ b/src/reducers/counterpartField.js
@@ -16,6 +16,8 @@ const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers:me
 //const debugData = debug.extend('data');
 const debugDev = debug.extend('dev');
 
+const irrelevantSubfieldsInNameAndTitlePartComparison = '5689';
+
 const counterpartRegexps = { // NB! tag is from source!
   // Note that in the normal case, all source 1XX fields have been converted to 7XX fields.
   '100': /^[17]00$/u, '110': /^[17]10$/u, '111': /^[17]11$/u, '130': /^[17]30$/u,
@@ -133,8 +135,8 @@ function optionalSubfieldComparison(originalBaseField, originalSourceField, keyS
     // When everything is the string, the strings need to be (practically) identical.
     // (NB! Here order matters. We should probably make it matter everywhere.)
     // (However, keySubfieldsAsString === '' will always succeed. Used by 040 at least.)
-    // TEE: SKIPPAA INDIKAATTORIT!
-    return fieldToString(field1) === fieldToString(field2);
+    // NB! substring(6) skips "TAG II" (I=indicator. Thus we skip indicators)
+    return fieldToString(field1).substring(6) === fieldToString(field2).substring(6);
   }
   const subfieldArray = keySubfieldsAsString.split('');
 
@@ -397,7 +399,9 @@ function pairableName(baseField, sourceField) {
     return true;
   }
 
-  nvdebug(`    name mismatch: '${fieldToString(reducedField1)}' vs '${fieldToString(reducedField2)}'`, debugDev);
+  nvdebug(`    name mismatch:`);
+  nvdebug(`     '${fieldToString(reducedField1)}' vs`);
+  nvdebug(`     '${fieldToString(reducedField2)}'`, debugDev);
   return false;
 }
 
@@ -441,7 +445,8 @@ function namePartThreshold(field) {
 
 function fieldToNamePart(field) {
   const index = namePartThreshold(field);
-  const relevantSubfields = field.subfields.filter((sf, i) => i < index || index === -1);
+  const relevantSubfields = field.subfields.filter((sf, i) => i < index || index === -1).filter(sf => !irrelevantSubfieldsInNameAndTitlePartComparison.includes(sf.code));
+
   const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: relevantSubfields};
 
   /*
@@ -449,13 +454,17 @@ function fieldToNamePart(field) {
     debugDev(`Name subset: ${fieldToString(subsetField)}`);
   }
   */
+
+  // Ummm... Sometimes $0 comes after $t but belongs to name part
+
   return subsetField;
 }
 
 function fieldToTitlePart(field) {
   // Take everything after 1st subfield $t...
   const index = field.subfields.findIndex(currSubfield => currSubfield.code === 't');
-  const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: field.subfields.filter((sf, i) => i >= index)};
+  const relevantSubfields = field.subfields.filter((sf, i) => i >= index).filter(sf => !irrelevantSubfieldsInNameAndTitlePartComparison.includes(sf.code));
+  const subsetField = {'tag': field.tag, 'ind1': field.ind1, 'ind2': field.ind2, subfields: relevantSubfields};
   debugDev(`Title subset: ${fieldToString(subsetField)}`);
   return subsetField;
 }

--- a/src/reducers/counterpartField.js
+++ b/src/reducers/counterpartField.js
@@ -41,7 +41,7 @@ function differentPublisherSubfields(field1, field2) {
 
 
 export function splitToNameAndQualifier(name) {
-  const nameOnly = name.replace(/(?: \([^)]+\)| abp?|, kustannusosakeyhtiö| oyj?| ry)$/ugi, '');
+  const nameOnly = name.replace(/(?: \([^)]+\)| abp?| Kustannus|, kustannusosakeyhtiö| oyj?| ry)$/ugi, '');
   if (nameOnly === name) {
     return [getBestName(name).toLowerCase(), undefined];
   }

--- a/src/reducers/mergableTag.js
+++ b/src/reducers/mergableTag.js
@@ -51,7 +51,7 @@ const defaultNonMergableFields = [
   '853',
   '854',
   '855',
-  // '856', // This is mergable but so risky, that let's just ignore these
+  // '856' is mergable, but a pain in the ass
   '863',
   '864',
   '865',
@@ -64,7 +64,7 @@ const defaultNonMergableFields = [
   '881',
   '882',
   '883',
-  '884',
+  // '884',
   '885',
   '886',
   '887',

--- a/src/reducers/mergeConstraints.js
+++ b/src/reducers/mergeConstraints.js
@@ -270,7 +270,7 @@ const mergeConstraints = [
   {'tag': '881', 'required': ''},
   {'tag': '882', 'required': ''},
   {'tag': '883', 'required': ''},
-  {'tag': '884', 'required': ''},
+  {'tag': '884', 'required': '', 'paired': 'agkq'},
   {'tag': '885', 'required': ''},
   {'tag': '886', 'required': ''},
   {'tag': '887', 'required': ''},

--- a/src/reducers/mergeField.js
+++ b/src/reducers/mergeField.js
@@ -48,7 +48,7 @@ export default (tagPattern = undefined, config = defaultConfig.mergeConfiguratio
   preprocessBeforeAdd(baseRecord, sourceRecord, config.preprocessorDirectives);
 
 
-  //sourceRecord.fields.forEach(f => nvdebug(`SRC2: ${fieldToString(f)}`));
+  //sourceRecord.fields.forEach(f => nvdebug(`SRC2: ${fieldToString(f)}`, debugDev));
 
   const candidateFields = sourceRecord.get(activeTagPattern);
   //  .filter(field => !isMainOrCorrespondingAddedEntryField(field)); // current handle main entries as well

--- a/test-fixtures/reducers/index/field710_MET502/base.json
+++ b/test-fixtures/reducers/index/field710_MET502/base.json
@@ -7,6 +7,10 @@
       { "code": "e", "value": "kustantaja." },
       {  "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo" },
+      { "code": "e", "value": "kustantaja." }
+    ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (foo)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "WSOY" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Ntamo" } ]},

--- a/test-fixtures/reducers/index/field710_MET502/base.json
+++ b/test-fixtures/reducers/index/field710_MET502/base.json
@@ -8,6 +8,10 @@
       {  "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Bazar," },
+      { "code": "e", "value": "kustantaja." }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
       { "code": "a", "value": "Paristo" },
       { "code": "e", "value": "kustantaja." }
     ]},

--- a/test-fixtures/reducers/index/field710_MET502/merged.json
+++ b/test-fixtures/reducers/index/field710_MET502/merged.json
@@ -7,6 +7,11 @@
       { "code": "e", "value": "kustantaja." },
       { "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
+      { "code": "e", "value": "kustantaja." },
+      {  "code": "0", "value": "(FI-ASTERI-N)000555889" }
+    ]},
 
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (foo)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Werner Söderström osakeyhtiö." } ]},

--- a/test-fixtures/reducers/index/field710_MET502/merged.json
+++ b/test-fixtures/reducers/index/field710_MET502/merged.json
@@ -8,6 +8,11 @@
       { "code": "0", "value": "(FI-ASTERI-N)000555888" }
     ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Bazar Kustannus," },
+      { "code": "e", "value": "kustantaja." },
+      { "code": "0", "value": "(FI-ASTERI-N)000219017" }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
       { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
       { "code": "e", "value": "kustantaja." },
       {  "code": "0", "value": "(FI-ASTERI-N)000555889" }

--- a/test-fixtures/reducers/index/field710_MET502/source.json
+++ b/test-fixtures/reducers/index/field710_MET502/source.json
@@ -6,6 +6,11 @@
       { "code": "a", "value": "Karisto" },
       { "code": "e", "value": "kustantaja." }
     ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
+      { "code": "e", "value": "kustantaja." },
+      {  "code": "0", "value": "(FI-ASTERI-N)000555889" }
+    ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Qualifier Mismatch (bar)" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "Werner Söderström osakeyhtiö" } ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [ { "code": "a", "value": "ntamo" } ]},

--- a/test-fixtures/reducers/index/field710_MET502/source.json
+++ b/test-fixtures/reducers/index/field710_MET502/source.json
@@ -7,6 +7,11 @@
       { "code": "e", "value": "kustantaja." }
     ]},
     { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Bazar Kustannus," },
+      { "code": "e", "value": "kustantaja." },
+      { "code": "0", "value": "(FI-ASTERI-N)000219017" }
+    ]},
+    { "tag": "710", "ind1": "2", "ind2": " ", "subfields": [
       { "code": "a", "value": "Paristo, kustannusosakeyhtiö," },
       { "code": "e", "value": "kustantaja." },
       {  "code": "0", "value": "(FI-ASTERI-N)000555889" }

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/base.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/base.json
@@ -9,7 +9,7 @@
       { "code": "9", "value": "FENNI<KEEP>" }
     ]},
     { "tag": "600", "ind1": "0", "ind2": "4", "subfields": [
-      { "code": "a", "value": "Harry," },
+      { "code": "a", "value": "harry," },
       { "code": "c", "value": "prinssi, Sussexin herttua." }
     ]},
     { "tag": "610", "ind1": "2", "ind2": "4", "subfields": [
@@ -20,7 +20,7 @@
       { "code": "a", "value": "Työväen paheistusliitto." }
     ]},
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-        { "code": "a", "value": "Manik, Dhyan," },
+        { "code": "a", "value": "Islantilainen, Joku" },
         { "code": "e", "value": "kirjoittaja." }
     ]}
   ]

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/merged.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/merged.json
@@ -24,12 +24,10 @@
       { "code": "a", "value": "Työväen paheistusliitto." },
       { "code": "0", "value": "(FI-ASTERI-N)323880000" }
     ]},
-    {
-      "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-        { "code": "a", "value": "Manik, Dhyan," },
-        { "code": "e", "value": "kirjoittaja." },
-        { "code": "0", "value": "(FI-ASTERI-N)000077333" }
-      ]
-    }
+    { "tag": "700", "ind1": "0", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Joku Islantilainen," },
+      { "code": "e", "value": "kirjoittaja."},
+      { "code": "0", "value": "(FI-ASTERI-N)000077333" }
+    ]}
   ]
 }

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/metadata.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/metadata.json
@@ -1,5 +1,6 @@
 {
   "description":"00 merge X00, keep 710. Now also test MRA-331, MRA-414.",
   "MRA-414": "600 and 610 fields should merge",
+  "NB #1": "MELINDA-506 prefers Harry and \"Joku Islantilainen\" field from source, since it has an Asteri $0 ",
   "only": false
 }

--- a/test-fixtures/reducers/mergeDataFields/mainEntry1/00/source.json
+++ b/test-fixtures/reducers/mergeDataFields/mainEntry1/00/source.json
@@ -6,7 +6,7 @@
       { "code": "c", "value": "Sussexin herttuatar." }
     ]},
     { "tag": "600", "ind1": "0", "ind2": "4", "subfields": [
-      { "code": "a", "value": "harry" },
+      { "code": "a", "value": "Harry," },
       { "code": "c", "value": "prinssi, Sussexin herttua." },
       { "code": "0", "value": "(FI-ASTERI-N)000189324" },
       { "code": "9", "value": "FENNI<KEEP>" }
@@ -20,7 +20,7 @@
     ]},
     { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "Tuisku, Sara." } ] },
     { "tag": "700", "ind1": "0", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Dhyan Manik." },
+      { "code": "a", "value": "Joku Islantilainen." },
       { "code": "0", "value": "(FI-ASTERI-N)000077333" }
     ]},
     { "tag": "710", "ind1": "1", "ind2": " ", "subfields": [ { "code": "a", "value": "Helsingin yliopisto." } ] }


### PR DESCRIPTION
Bumps the development-dependencies group with 2 updates: [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) and [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env).


Updates `@babel/core` from 7.23.2 to 7.23.3
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.23.3/packages/babel-core)

Updates `@babel/preset-env` from 7.23.2 to 7.23.3
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.23.3/packages/babel-preset-env)

---
updated-dependencies:
- dependency-name: "@babel/core" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: development-dependencies
- dependency-name: "@babel/preset-env" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: development-dependencies ...