### PR TITLE
F243

### DIFF
--- a/.github/workflows/melinda-node-tests-and-publish.yml
+++ b/.github/workflows/melinda-node-tests-and-publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@master
@@ -53,7 +53,7 @@ jobs:
     container: node:24
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: mikaelvesavuori/license-compliance-action@v1
         with:
           exclude_pattern: /^@natlibfi/
@@ -65,7 +65,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.1.7",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record": "^10.0.2",
 				"@natlibfi/marc-record-merge": "^8.0.1",
 				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 				"clone": "^2.1.2",
@@ -726,9 +726,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.1.tgz",
-			"integrity": "sha512-ENEMr0sMyM/LUViZ/+/SKQq/u9gju8GBKY4Rx+NsQ1JhV69F0/YbURropawG6eZHZJx0IlO7ncYZPJ6DfqWFHQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.2.tgz",
+			"integrity": "sha512-4w+YskqHX6IgHXJK6cy7RYJjamuMh/mrBEMLlsQVNJLUU7iv+0RsMBJdBYdyap5krBGVYYKGJwNiJkQy9V4JDA==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
 				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.6"
+				"isbn3": "^2.0.7"
 			},
 			"devDependencies": {
 				"@natlibfi/fixugen": "^3.0.1",
 				"@natlibfi/fixura": "^4.0.1",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.28.0",
-				"eslint": "^10.2.1"
+				"eslint": "^10.3.0"
 			},
 			"engines": {
 				"node": ">=22"
@@ -1385,9 +1385,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-			"integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+			"integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1798,9 +1798,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.6.tgz",
-			"integrity": "sha512-RrJy7jsXki4+QK/D2/ZH2lKi3oOr+xcgIMf2VXrDZ3DduE4awmu2XJ0Z/zu5j0L6XIGWbJUhe0UYD2BlRgwLrA==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.7.tgz",
+			"integrity": "sha512-FYsoxXRHwj7GGr9xVp4UigwMWJFMzCYbDxWAb17/BG7d3Ml7TnzWxIyZhNtLvD1NVrUrzKF/MT9xogVFfd+jAQ==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@natlibfi/whatever-uses-branch": "github:natlibfi/marc-record-validators-melinda#branchName"
 	},
 	"dependencies": {
-		"@natlibfi/marc-record": "^10.0.1",
+		"@natlibfi/marc-record": "^10.0.2",
 		"@natlibfi/marc-record-merge": "^8.0.1",
 		"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 		"clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
 		"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 		"clone": "^2.1.2",
 		"debug": "^4.4.3",
-		"isbn3": "^2.0.6"
+		"isbn3": "^2.0.7"
 	},
 	"devDependencies": {
 		"@natlibfi/fixugen": "^3.0.1",
 		"@natlibfi/fixura": "^4.0.1",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.0",
-		"eslint": "^10.2.1"
+		"eslint": "^10.3.0"
 	}
 }

--- a/src/reducers/mergeField.js
+++ b/src/reducers/mergeField.js
@@ -39,7 +39,7 @@ export default (tagPattern = undefined, config = defaultConfig.mergeConfiguratio
   fixer.fix(baseRecord);
   fixer.fix(sourceRecord);
 
-  retagSourceFields(sourceRecord, baseRecord);
+  retagSourceFields(sourceRecord, baseRecord); // source f100->f700
   preprocessBeforeAdd(baseRecord, sourceRecord, config.preprocessorDirectives, internal); // NB! we should rename func, this may have nothing to with add
 
 
@@ -72,6 +72,9 @@ export default (tagPattern = undefined, config = defaultConfig.mergeConfiguratio
 };
 
 export function retagSourceFields(record, baseRecord) {
+  const base240 = baseRecord.get('240');
+  const base243 = baseRecord.get('243');
+
   record.fields.forEach(f => retagField(f));
 
   // NB! 880$6 stuff is nor currently checked...
@@ -90,13 +93,18 @@ export function retagSourceFields(record, baseRecord) {
       field.ind1 = '1';
       // NB! 130 might have a $t, but that's so theoretical, that I'm not checking nor handling it.
       // No other known differences (subfields, punctuation etc.)
+      // return; // We might feed the f240->f243 rule
+    }
+
+    // 240 and 243 should not co-exist -> make source use the same tag as base
+    if (field.tag === '240' && base240.length === 0 && base243.length > 0) {
+      field.tag = '243';
       return;
     }
-    if (field.tag === '243') {
-      const base243 = baseRecord.get('243');
-      if (base243) {
-        field.tag = '240';
-      }
+    if (field.tag === '243' && base240.length > 0 && base243.length === 0) {
+      field.tag = '240';
+      return;
     }
+
   }
 }

--- a/src/reducers/mergeField.js
+++ b/src/reducers/mergeField.js
@@ -39,7 +39,7 @@ export default (tagPattern = undefined, config = defaultConfig.mergeConfiguratio
   fixer.fix(baseRecord);
   fixer.fix(sourceRecord);
 
-  retagSource1XX(sourceRecord);
+  retagSourceFields(sourceRecord, baseRecord);
   preprocessBeforeAdd(baseRecord, sourceRecord, config.preprocessorDirectives, internal); // NB! we should rename func, this may have nothing to with add
 
 
@@ -71,7 +71,7 @@ export default (tagPattern = undefined, config = defaultConfig.mergeConfiguratio
   }
 };
 
-export function retagSource1XX(record) {
+export function retagSourceFields(record, baseRecord) {
   record.fields.forEach(f => retagField(f));
 
   // NB! 880$6 stuff is nor currently checked...
@@ -91,6 +91,12 @@ export function retagSource1XX(record) {
       // NB! 130 might have a $t, but that's so theoretical, that I'm not checking nor handling it.
       // No other known differences (subfields, punctuation etc.)
       return;
+    }
+    if (field.tag === '243') {
+      const base243 = baseRecord.get('243');
+      if (base243) {
+        field.tag = '240';
+      }
     }
   }
 }

--- a/src/reducers/muuntajaConfig.json
+++ b/src/reducers/muuntajaConfig.json
@@ -176,47 +176,6 @@
     "addConfiguration" : {
         "preprocessorDirectives" : [
             {
-                "operation": "retag",
-                "recordType": "source",
-                "fieldSpecification": {"tag": "100"},
-                "newTag": "700",
-                "requireBaseField": {
-                    "tagPattern": "^1..$"
-                }
-            },
-
-            {
-                "operation": "retag",
-                "recordType": "source",
-                "fieldSpecification": {"tag": "110"},
-                "newTag": "710",
-                "requireBaseField": {
-                    "tagPattern": "^1..$"
-                }
-
-            },
-
-            {
-                "operation": "retag",
-                "recordType": "source",
-                "fieldSpecification": {"tag": "111"},
-                "newTag": "711",
-                "requireBaseField": {
-                    "tagPattern": "^1..$"
-                }
-            },
-
-            {
-                "operation": "retag",
-                "recordType": "source",
-                "fieldSpecification": {"tag": "130"},
-                "newTag": "730",
-                "requireBaseField": {
-                    "tagPattern": "^1..$"
-                }
-            },
-            
-            {
                 "operation": "removeField",
                 "comment": "this should be done after field merge and before copy (could be merged, but not added)",
                 "recordType": "source",

--- a/src/reducers/transferManufacturerDataFrom260To264.js
+++ b/src/reducers/transferManufacturerDataFrom260To264.js
@@ -30,7 +30,7 @@ function hasNonManufacturerData(field) {
   return field.subfields.some(subfield => ['a', 'b', 'c'].includes(subfield.code));
 }
 
-function retagableField(field) {
+function retagableManufacturerField(field) {
   return !hasNonManufacturerData(field) && !hasTooMuchManufacturerData(field);
 }
 
@@ -108,7 +108,7 @@ function extractField(field) {
 
 }
 
-function retag(field) {
+function retagManufacturer(field) {
   field.tag = '264';
   field.ind2 = '3';
   field.subfields.forEach(subfield => renameSubfield(subfield));
@@ -132,8 +132,8 @@ function handleRecord(record) {
   relevantFields.forEach(field => processField(field));
 
   function processField(field) {
-    if (retagableField(field)) {
-      retag(field);
+    if (retagableManufacturerField(field)) {
+      retagManufacturer(field);
       return;
     }
     const newField = extractField(field);

--- a/test-fixtures/reducers/index/field_240_MET809/base.json
+++ b/test-fixtures/reducers/index/field_240_MET809/base.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "240", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sonaatit," },
+        { "code": "m", "value": "piano." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}

--- a/test-fixtures/reducers/index/field_240_MET809/merged.json
+++ b/test-fixtures/reducers/index/field_240_MET809/merged.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "240", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sonaatit," },
+        { "code": "m", "value": "piano." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}

--- a/test-fixtures/reducers/index/field_240_MET809/metadata.json
+++ b/test-fixtures/reducers/index/field_240_MET809/metadata.json
@@ -1,0 +1,4 @@
+{
+  "description":"MET-809: f243 (NR) vs f240 (NR) should not appear together",
+  "only": false
+}

--- a/test-fixtures/reducers/index/field_240_MET809/modifiedSource.json
+++ b/test-fixtures/reducers/index/field_240_MET809/modifiedSource.json
@@ -1,0 +1,6 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "source-1" }
+  ]
+}

--- a/test-fixtures/reducers/index/field_240_MET809/source.json
+++ b/test-fixtures/reducers/index/field_240_MET809/source.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "source-1" },
+    { "tag": "243", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sonaatit." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}

--- a/test-fixtures/reducers/index/field_243_MET809/base.json
+++ b/test-fixtures/reducers/index/field_243_MET809/base.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "243", "ind1": "1", "ind2": "0", "subfields": [ 
+        { "code": "a", "value": "Sonaatit," },
+        { "code": "m", "value": "piano." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}

--- a/test-fixtures/reducers/index/field_243_MET809/merged.json
+++ b/test-fixtures/reducers/index/field_243_MET809/merged.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "243", "ind1": "1", "ind2": "0", "subfields": [ 
+        { "code": "a", "value": "Sonaatit," },
+        { "code": "m", "value": "piano." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}

--- a/test-fixtures/reducers/index/field_243_MET809/metadata.json
+++ b/test-fixtures/reducers/index/field_243_MET809/metadata.json
@@ -1,0 +1,4 @@
+{
+  "description":"MET-809: f243 (NR) vs f240 (NR) should not appear together",
+  "only": false
+}

--- a/test-fixtures/reducers/index/field_243_MET809/modifiedSource.json
+++ b/test-fixtures/reducers/index/field_243_MET809/modifiedSource.json
@@ -1,0 +1,6 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "source-1" }
+  ]
+}

--- a/test-fixtures/reducers/index/field_243_MET809/source.json
+++ b/test-fixtures/reducers/index/field_243_MET809/source.json
@@ -3,7 +3,8 @@
   "fields": [
     { "tag": "001", "value": "source-1" },
     { "tag": "240", "ind1": "1", "ind2": "0", "subfields": [
-        { "code": "a", "value": "Sonaatit." },
+        { "code": "a", "value": "Sonaatit," },
+        { "code": "m", "value": "piano." },
         { "code": "k", "value": "Valikoima" }
     ] }
   ]

--- a/test-fixtures/reducers/index/field_243_MET809/source.json
+++ b/test-fixtures/reducers/index/field_243_MET809/source.json
@@ -1,0 +1,10 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "source-1" },
+    { "tag": "240", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sonaatit." },
+        { "code": "k", "value": "Valikoima" }
+    ] }
+  ]
+}


### PR DESCRIPTION
If both fields have a f243, and they are not merged, retag source f243->f240 after field-merge and before field-add. Otherwise non-repeatable f243 would be lost.

Rename some retagging functions.

Remove some long-deprecated 'retag' operations. (f130->f240 operation was so complex that it could not be handled by straight-forward json rules. Retag stuff is nowadays hard-coded.)

Also update deps (inclunding xlmdom security update).