### PR TITLE
Ignore LDR mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-marc-record-merge-reducers",
-	"version": "3.2.0",
+	"version": "3.2.1-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-marc-record-merge-reducers",
-			"version": "3.2.0",
+			"version": "3.2.1-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/NatLibFi/melinda-marc-record-merge-reducers-js"
 	},
 	"license": "MIT",
-	"version": "3.2.0",
+	"version": "3.2.1-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=22"

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -42,7 +42,7 @@ export const localReducers = [
 
   //// ACTUAL MERGE/ADD STUFF:
   //internalFields(), // LOW, CAT, SID. Nowadays part of genericDatafield()
-  leader(), // Test 01 // (no config) (1. param ignoreLDRmismatch, defaults to false so that differing LDR/06 + LDR/07 are errored
+  leader(true), // Test 01 // (no config) (1. param ignoreLDRmismatch, defaults to false so that differing LDR/06 + LDR/07 are errored
   field006(), // Tests 02 and 03 // (no config)
   field007(), // Tests 04 and 05 // (no config)
   field008(), // Tests 06, 07, and 08 // (no config)


### PR DESCRIPTION
Ignore LDR/06+LDR/07 mismatches also in generic localReducers setup.
Reducers are able to handle merging records, where LDR/06+07 differ. 
Merge-decision should be made before sending records to merge.

